### PR TITLE
Fix corner case generation issue

### DIFF
--- a/synthetic_workload_invoker/EventGenerator.py
+++ b/synthetic_workload_invoker/EventGenerator.py
@@ -43,7 +43,8 @@ def EnforceActivityWindow(start_time, end_time, instance_events):
     """
     events_iit = []
     events_abs = [0] + instance_events
-    event_times = [sum(events_abs[:i]) for i in range(1, len(events_abs))]
+    event_times = [sum(events_abs[:i]) for i in range(1, len(events_abs) + 1)]
+    # import pdb; pdb.set_trace()
     event_times = [e for e in event_times if (e > start_time)and(e < end_time)]
     try:
         events_iit = [event_times[0]] + [event_times[i]-event_times[i-1]

--- a/synthetic_workload_invoker/EventGenerator.py
+++ b/synthetic_workload_invoker/EventGenerator.py
@@ -44,7 +44,6 @@ def EnforceActivityWindow(start_time, end_time, instance_events):
     events_iit = []
     events_abs = [0] + instance_events
     event_times = [sum(events_abs[:i]) for i in range(1, len(events_abs) + 1)]
-    # import pdb; pdb.set_trace()
     event_times = [e for e in event_times if (e > start_time)and(e < end_time)]
     try:
         events_iit = [event_times[0]] + [event_times[i]-event_times[i-1]


### PR DESCRIPTION
Corner case:

It would be great to have this fix to simulate some cold start scenarios. 

For example, if we generate a Poisson distribution with the rate of 0.016 in 60s, and we would expect to see around 1 invocation per minute.

Let’s assume that it happens at 30s, which means `instance_events = [30]`, then `events_abs = [0, 30]`, and ideally we should see `event_times = [0, 30]`
For current implementation:` event_times = [sum(events_abs[:i]) for i in range(1, len(events_abs))] `,
 `event_times = [0]`, which is further filtered out with the start time = 0 in the next line. 

The fix can help with observing one invocation, which is the expected result. 